### PR TITLE
feature: Add Search API back

### DIFF
--- a/addons/themes/theme-nexfoundation/src/scss/custom.scss
+++ b/addons/themes/theme-nexfoundation/src/scss/custom.scss
@@ -9,3 +9,8 @@
 @import "~@vanilla/theme-core/scss/dynamic";
 @import "mixins/mixins";
 @import "components/ad";
+
+.search-filter {
+  display: none !important;
+  visibility: hidden;
+}

--- a/applications/dashboard/controllers/api/SearchApiController.php
+++ b/applications/dashboard/controllers/api/SearchApiController.php
@@ -1,0 +1,105 @@
+<?php
+
+use Vanilla\ApiUtils;
+use Garden\Web\Data;
+use Vanilla\Formatting\Formats\TextFormat;
+
+class SearchApiController extends AbstractApiController {
+
+    use \Vanilla\Formatting\FormatCompatTrait;
+
+    /** @var SearchModel */
+    private $searchModel;
+
+    public function __construct(SearchModel $searchModel = null) {
+        if ($searchModel === null) {
+            $searchModel = new SearchModel();
+        }
+        $this->searchModel = $searchModel;
+    }
+
+    public function index(array $query) {
+        $this->permission();
+
+        $in =  $this->schema([
+            'domain:s' => [
+                'description' => 'all or discussions',
+                'enum' => ['all_content', 'discussions'],
+                'default'=> 'all_content'
+            ],
+            'query:s' => [
+                'description' => 'query string',
+                'default'=> ''
+            ],
+            'page:i?' => [
+                'description' => 'Page number.',
+                'default' => 1,
+                'minimum' => 1,
+                'maximum' => 100
+            ],
+            'limit:i?' => [
+                'description' => 'Desired number of items per page.',
+                'default' => 10,
+                'minimum' => 1,
+                'maximum' => 100
+            ]
+            ], 'in');
+
+        $query = $in->validate($query);
+
+        if ($query['query'] == '') {
+            return new Data([], [], ['link' => '']);
+        }
+
+        $this->searchModel->setSearchDomain($query['domain']);
+        $resultCount = $this->searchModel->searchCount($query['query']);
+        $resultSet = $this->searchModel->search($query['query'], $query['page']-1, $query['limit']);
+        foreach ($resultSet as &$row) {
+            $row = $this->normalizeOutput($row);
+        }
+        $paging = ApiUtils::numberedPagerInfo($resultCount, '/api/v2/search', $query, $in);
+        return new Data(
+            $resultSet, [],
+            [
+                'link' => $this->pagerLink($paging),
+                'x-app-page-result-count' => $resultCount,
+                'x-app-page-current' => 1,
+                'x-app-page-limit' => 10
+            ]);
+    }
+
+    private function pagerLink($paging) {
+        if (
+            !isset($paging['urlFormat']) ||
+            !isset($paging['page']) ||
+            !isset($paging['pageCount'])
+        ) {
+            return "";
+        }
+        $urlFormat = $paging['urlFormat'];
+        $page = $paging['page'];
+        $pageCount = $paging['pageCount'];
+        $links = [];
+        if ($page > 1) {
+            $links[] = '<'.sprintf($urlFormat, $page-1).'>; rel="prev"';
+        }
+        if ($page < $pageCount) {
+            $links[] = '<'.sprintf($urlFormat, $page+1).'>; rel="next"';
+        }
+        return implode(',', $links);
+    }
+
+    private function normalizeOutput(array $record) {
+        // die(var_dump($record));
+        $normalized = [];
+        $normalized['name'] = $record['Title'];
+        $normalized['url'] = $record['Url'];
+        $normalized['body'] = Gdn::formatService()->renderPlainText($record['Summary'], "html");
+        $normalized['recordID'] = $record['PrimaryID'];
+        $normalized['type'] = $normalized['recordType'] = strtolower($record['RecordType']);
+        $normalized['breadcrumbs'] = [];
+        $normalized['dateInserted'] = $record['DateInserted'];
+        $normalized['score'] = $record['Relevance'];
+        return $normalized;
+    }
+}

--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -281,4 +281,22 @@ class SearchModel extends Gdn_Model {
         $html = preg_replace('`/>\s*<br />\s*<img`', "/> <img", $html);
         return $html;
     }
+
+    public function getDiscussionsIn($discussionIDs) {
+        $sql = $this->SQL
+            ->select('d.DiscussionID as PrimaryID, d.DiscussionID, d.Name, d.Name as Title, d.Body as Summary, d.Format, d.CategoryID, d.Score')
+            ->select('d.DiscussionID', "concat('/discussion/', %s)", 'Url')
+            ->select('d.DateInserted')
+            ->select('d.InsertUserID as UserID')
+            ->select("'Discussion'", '', 'RecordType')
+            ->from('Discussion d')
+            ->orderBy('d.DateInserted', 'desc')
+            ->whereIn('d.DiscussionID', $discussionIDs)
+            ->getSelect()
+        ;
+
+        $this->SQL->reset();
+        $result = $this->Database->query($sql)->resultArray();
+        return $result;
+    }
 }

--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -28,6 +28,11 @@ class SearchModel extends Gdn_Model {
     /** @var string Search string. */
     protected $_SearchText = '';
 
+    /** @var string Search domain, either 'all_content' or 'discussions' */
+    protected $_SearchDomain = 'all_content';
+
+    protected $_SearchDomains = ['all_content', 'discussions'];
+
     /**
      *
      *
@@ -94,7 +99,13 @@ class SearchModel extends Gdn_Model {
      */
     public function reset() {
         $this->_Parameters = [];
-        $this->_SearchSql = '';
+        $this->_SearchSql = [];
+    }
+
+    public function setSearchDomain($domain) {
+        if (in_array($domain, $this->_SearchDomains)) {
+            $this->_SearchDomain = $domain;
+        }
     }
 
     /**
@@ -111,39 +122,12 @@ class SearchModel extends Gdn_Model {
         if (trim($search) == '') {
             return [];
         }
-
         // Figure out the exact search mode.
-        if ($this->ForceSearchMode) {
-            $searchMode = $this->ForceSearchMode;
-        } else {
-            $searchMode = strtolower(c('Garden.Search.Mode', 'matchboolean'));
-        }
-
-        if ($searchMode == 'matchboolean') {
-            if (strpos($search, '+') !== false || strpos($search, '-') !== false) {
-                $searchMode = 'boolean';
-            } else {
-                $searchMode = 'match';
-            }
-        } else {
-            $this->_SearchMode = $searchMode;
-        }
-
-        if ($forceDatabaseEngine = c('Database.ForceStorageEngine')) {
-            if (strcasecmp($forceDatabaseEngine, 'myisam') != 0) {
-                $searchMode = 'like';
-            }
-        }
-
-        if (strlen($search) <= 4) {
-            $searchMode = 'like';
-        }
-
-        $this->_SearchMode = $searchMode;
-
+        $this->_SearchMode = $this->detectSearchMode($search);
         $this->EventArguments['Search'] = $search;
         $this->EventArguments['Limit'] = $limit;
         $this->EventArguments['Offset'] = $offset;
+        $this->EventArguments['Domain'] = $this->_SearchDomain;
         $this->fireEvent('Search');
 
         if (count($this->_SearchSql) == 0) {
@@ -195,8 +179,81 @@ class SearchModel extends Gdn_Model {
                     break;
             }
         }
-
         return $result;
+    }
+
+    /**
+     *
+     * get the total search result count for the $search string
+     *
+     * @param string $search
+     * @return int
+     *
+     */
+    public function searchCount($search) {
+        if (trim($search) == '') {
+            return 0;
+        }
+
+        $this->_SearchMode = $this->detectSearchMode($search);
+
+        $this->EventArguments['Search'] = $search;
+        $this->EventArguments['Domain'] = $this->_SearchDomain;
+        $this->fireEvent('Search');
+        if (count($this->_SearchSql) == 0) {
+            return 0;
+        }
+
+        $sql = "select count(*) as count from "."(\n".implode("\nunion all\n", $this->_SearchSql)."\n) s";
+        $this->fireEvent('AfterBuildSearchQuery');
+        if ($this->_SearchMode == 'like') {
+            $search = '%'.$search.'%';
+        }
+        foreach ($this->_Parameters as $key => $value) {
+            $this->_Parameters[$key] = $search;
+        }
+        $parameters = $this->_Parameters;
+        $this->reset();
+        $this->SQL->reset();
+        $result = $this->Database->query($sql, $parameters)->resultArray();
+        if (count($result) <= 0 ) {
+            return 0;
+        }
+        return $result[0]['count'];
+    }
+
+    /**
+     *
+     * Figure out the exact search mode.
+     *
+     * @param string $search
+     * @return string
+     */
+    private function detectSearchMode($search) {
+        $searchMode = strtolower(c('Garden.Search.Mode', 'matchboolean'));
+
+        if ($this->ForceSearchMode) {
+            $searchMode = $this->ForceSearchMode;
+        }
+
+        if ($searchMode == 'matchboolean') {
+            if (strpos($search, '+') !== false || strpos($search, '-') !== false) {
+                $searchMode = 'boolean';
+            } else {
+                $searchMode = 'match';
+            }
+        }
+
+        if ($forceDatabaseEngine = c('Database.ForceStorageEngine')) {
+            if (strcasecmp($forceDatabaseEngine, 'myisam') != 0) {
+                $searchMode = 'like';
+            }
+        }
+
+        if (strlen($search) <= 4) {
+            $searchMode = 'like';
+        }
+        return $searchMode;
     }
 
     /**

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -145,4 +145,8 @@ class VanillaSearchModel extends Gdn_Model {
         $searchModel->addSearch($this->discussionSql($searchModel));
         $searchModel->addSearch($this->commentSql($searchModel));
     }
+
+    public function searchDiscussion($searchModel) {
+        $searchModel->addSearch($this->discussionSql($searchModel));
+    }
 }

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -855,8 +855,12 @@ class VanillaHooks extends Gdn_Plugin {
      *
      * @param object $sender SearchModel
      */
-    public function searchModel_search_handler($sender) {
+    public function searchModel_search_handler($sender, $args = []) {
         $searchModel = new VanillaSearchModel();
+        if (isset($args['Domain']) && $args['Domain'] == 'discussions') {
+            $searchModel->searchDiscussion($sender);
+            return;
+        }
         $searchModel->search($sender);
     }
 

--- a/library/src/scripts/contexts/SearchContext.tsx
+++ b/library/src/scripts/contexts/SearchContext.tsx
@@ -13,7 +13,7 @@ import { formatUrl } from "@library/utility/appUtils";
 const defaultOptionProvider: ISearchOptionProvider = {
     supportsAutoComplete: false,
     autocomplete: () => Promise.resolve([]),
-    makeSearchUrl: query => formatUrl(`/search?search=${query}`),
+    makeSearchUrl: query => formatUrl(`/search?search=${query}&query=${query}`),
 };
 
 const SearchContext = React.createContext<IWithSearchProps>({

--- a/library/src/scripts/search/SearchPage.tsx
+++ b/library/src/scripts/search/SearchPage.tsx
@@ -142,7 +142,7 @@ function SearchPage(props: IProps) {
                         </>
                     }
                     mainBottom={<SearchPageResults />}
-                    rightTop={!isCompact && <PanelWidget>{currentFilter}</PanelWidget>}
+                    rightTop={!isCompact && <PanelWidget className="search-filter">{currentFilter}</PanelWidget>}
                 />
             </Container>
         </DocumentTitle>


### PR DESCRIPTION
Add search API back for AJAX query. However it disable many features, such as:
- filter
- search text highligh
- poster (user avatar and information)

See #4 for more detail

---

❗ Notice

MySQL didn't enable FullText Search Indexing by default, please run following SQL by yourself to add the indexing:

```sql
alter table GDN_Discussion ADD FULLTEXT index dicussion_body(Body);
alter table GDN_Discussion ADD FULLTEXT index dicussion_ft(Name,Body);
alter table GDN_Comment ADD FULLTEXT index comment_body(body);
```