### PR TITLE
hotfix: composer version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           php-version: "7.2.19"
           extensions: mbstring, intl, curl, dom
-          tools: composer
+          tools: composer:v1
 
       - name: Install Composer Packages
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           php-version: "7.2"
           extensions: mbstring, intl, curl, dom
-          tools: composer
+          tools: composer:v1
 
       - name: Install Composer Packages
         env:


### PR DESCRIPTION
Force to use composer v1 in CI flow
It's due to the composer v2 release
