### PR TITLE
fix: css warning

### DIFF
--- a/addons/themes/theme-nexfoundation/src/scss/components/_article.scss
+++ b/addons/themes/theme-nexfoundation/src/scss/components/_article.scss
@@ -69,7 +69,7 @@
     @include md {
         width: 100%;
         display: flex;
-        align-items: start;
+        align-items: flex-start;
     }
 }
 
@@ -107,7 +107,7 @@
         .Item-Footer .Item-Header.CommentHeader {
             display: flex;
             justify-content: flex-end;
-            align-items: start;
+            align-items: flex-start;
             padding: 0px;
             .Meta.CommentMeta.CommentInfo {
                 width: initial;


### PR DESCRIPTION
Misuse `start` instead of `flex-start` in some alignment css settings.